### PR TITLE
Add support for rayon-based sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "paste",
  "pdqselect",
  "rand",
+ "rayon",
  "typenum",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ ordered-float = "2.0.0"
 pdqselect = "0.1.0"
 typenum = "1.12"
 paste = "1.0"
+rayon = { version = "1.5", optional = true }
 
 [dev-dependencies]
 rand = "0.7.3"
 criterion = "0.3"
-fux_kdtree = { version = "0.2.0", package = "fux_kdtree" } 
+fux_kdtree = { version = "0.2.0", package = "fux_kdtree" }
 kdtree = "0.6.0"
 
 [[bench]]

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -20,6 +20,25 @@ fn bench_kdtree_construction(c: &mut Criterion) {
                 b.iter(|| KdTree::build(points.clone()));
             },
         );
+        #[cfg(feature = "rayon")]
+        {
+            group.bench_with_input(
+                BenchmarkId::new("kd_tree + rayon (f64)", log10n),
+                log10n,
+                |b, log10n| {
+                    let points = gen_points3d(10usize.pow(*log10n));
+                    b.iter(|| KdTree::par_build_by_ordered_float(points.clone()));
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("kd_tree + rayon (i32)", log10n),
+                log10n,
+                |b, log10n| {
+                    let points = gen_points3i(10usize.pow(*log10n));
+                    b.iter(|| KdTree::par_build(points.clone()));
+                },
+            );
+        }
         group.bench_with_input(
             BenchmarkId::new("kd_index_tree", log10n),
             log10n,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
         Key: Ord,
         F: Fn(&T, usize) -> Key + Copy + Send,
     {
-        Self::build_by(source, |item1, item2, k| {
+        Self::par_build_by(source, |item1, item2, k| {
             kd_key(item1, k).cmp(&kd_key(item2, k))
         })
     }
@@ -744,7 +744,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
         T: KdPoint<Dim = N>,
         T::Scalar: num_traits::Float,
     {
-        Self::build_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
+        Self::par_build_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
     }
 
     pub fn par_build(points: &'a [T]) -> Self
@@ -752,7 +752,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
         T: KdPoint<Dim = N>,
         T::Scalar: Ord,
     {
-        Self::build_by_key(points, |item, k| item.at(k))
+        Self::par_build_by_key(points, |item, k| item.at(k))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,45 @@ impl<T, N: Unsigned> KdSliceN<T, N> {
         self.within_radius_by(query, radius, |item, k| item.at(k))
     }
 }
+#[cfg(feature = "rayon")]
+impl<T: Send, N: Unsigned> KdSliceN<T, N> {
+    /// Same as [`Self::sort_by`], but using multiple threads.
+    pub fn par_sort_by<F>(items: &mut [T], compare: F) -> &Self
+    where
+        F: Fn(&T, &T, usize) -> Ordering + Copy + Send,
+    {
+        kd_par_sort_by(items, N::to_usize(), compare);
+        unsafe { Self::new_unchecked(items) }
+    }
+
+    /// Same as [`Self::sort_by_key`], but using multiple threads.
+    pub fn par_sort_by_key<Key: Ord, F>(items: &mut [T], kd_key: F) -> &Self
+    where
+        F: Fn(&T, usize) -> Key + Copy + Send,
+    {
+        Self::par_sort_by(items, move |item1, item2, k| {
+            kd_key(item1, k).cmp(&kd_key(item2, k))
+        })
+    }
+
+    /// Same as [`Self::sort_by_ordered_float`], but using multiple threads.
+    pub fn par_sort_by_ordered_float(points: &mut [T]) -> &Self
+    where
+        T: KdPoint<Dim = N>,
+        T::Scalar: num_traits::Float,
+    {
+        Self::par_sort_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
+    }
+
+    /// Same as [`Self::sort`], but using multiple threads.
+    pub fn par_sort(points: &mut [T]) -> &Self
+    where
+        T: KdPoint<Dim = N>,
+        T::Scalar: Ord,
+    {
+        Self::par_sort_by_key(points, |item, k| item.at(k))
+    }
+}
 
 /// An owned kd-tree.
 /// This type implements [`std::ops::Deref`] to [`KdSlice`].
@@ -471,6 +510,46 @@ impl<T, N: Unsigned> KdTreeN<T, N> {
         T::Scalar: Ord,
     {
         Self::build_by_key(points, |item, k| item.at(k))
+    }
+}
+#[cfg(feature = "rayon")]
+impl<T: Send, N: Unsigned> KdTreeN<T, N> {
+    /// Same as [`Self::build_by`], but using multiple threads.
+    pub fn par_build_by<F>(mut items: Vec<T>, compare: F) -> Self
+    where
+        F: Fn(&T, &T, usize) -> Ordering + Copy + Send,
+    {
+        kd_par_sort_by(&mut items, N::to_usize(), compare);
+        Self(PhantomData, items)
+    }
+
+    /// Same as [`Self::build_by_key`], but using multiple threads.
+    pub fn par_build_by_key<Key, F>(items: Vec<T>, kd_key: F) -> Self
+    where
+        Key: Ord,
+        F: Fn(&T, usize) -> Key + Copy + Send,
+    {
+        Self::par_build_by(items, move |item1, item2, k| {
+            kd_key(item1, k).cmp(&kd_key(item2, k))
+        })
+    }
+
+    /// Same as [`Self::build_by_ordered_float`], but using multiple threads.
+    pub fn par_build_by_ordered_float(points: Vec<T>) -> Self
+    where
+        T: KdPoint<Dim = N>,
+        T::Scalar: num_traits::Float,
+    {
+        Self::par_build_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
+    }
+
+    /// Same as [`Self::build`], but using multiple threads.
+    pub fn par_build(points: Vec<T>) -> Self
+    where
+        T: KdPoint<Dim = N>,
+        T::Scalar: Ord,
+    {
+        Self::par_build_by_key(points, |item, k| item.at(k))
     }
 }
 
@@ -634,6 +713,46 @@ impl<'a, T, N: Unsigned> KdIndexTreeN<'a, T, N> {
         T: KdPoint<Dim = N>,
     {
         self.within_radius_by(query, radius, |item, k| item.at(k))
+    }
+}
+#[cfg(feature = "rayon")]
+impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
+    pub fn par_build_by<F>(source: &'a [T], compare: F) -> Self
+    where
+        F: Fn(&T, &T, usize) -> Ordering + Copy + Send,
+    {
+        Self {
+            source,
+            kdtree: KdTreeN::par_build_by((0..source.len()).collect(), move |i1, i2, k| {
+                compare(&source[*i1], &source[*i2], k)
+            }),
+        }
+    }
+
+    pub fn par_build_by_key<Key, F>(source: &'a [T], kd_key: F) -> Self
+    where
+        Key: Ord,
+        F: Fn(&T, usize) -> Key + Copy + Send,
+    {
+        Self::build_by(source, |item1, item2, k| {
+            kd_key(item1, k).cmp(&kd_key(item2, k))
+        })
+    }
+
+    pub fn par_build_by_ordered_float(points: &'a [T]) -> Self
+    where
+        T: KdPoint<Dim = N>,
+        T::Scalar: num_traits::Float,
+    {
+        Self::build_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
+    }
+
+    pub fn par_build(points: &'a [T]) -> Self
+    where
+        T: KdPoint<Dim = N>,
+        T::Scalar: Ord,
+    {
+        Self::build_by_key(points, |item, k| item.at(k))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,7 +734,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
         Key: Ord,
         F: Fn(&T, usize) -> Key + Copy + Send,
     {
-        Self::par_build_by(source, |item1, item2, k| {
+        Self::par_build_by(source, move |item1, item2, k| {
             kd_key(item1, k).cmp(&kd_key(item2, k))
         })
     }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,34 +1,4 @@
-use crate::KdPoint;
 use std::cmp::Ordering;
-
-#[allow(dead_code)]
-pub fn kd_sort<P: KdPoint>(points: &mut [P])
-where
-    P::Scalar: Ord,
-{
-    kd_sort_by_key(points, P::dim(), |item, k| item.at(k))
-}
-
-#[allow(dead_code)]
-pub fn kd_sort_by_ordered_float<P: KdPoint>(points: &mut [P])
-where
-    P::Scalar: num_traits::Float,
-{
-    kd_sort_by_key(points, P::dim(), |item, k| {
-        ordered_float::OrderedFloat(item.at(k))
-    })
-}
-
-#[allow(dead_code)]
-pub fn kd_sort_by_key<T, Key: Ord>(
-    items: &mut [T],
-    dim: usize,
-    kd_key: impl Fn(&T, usize) -> Key + Copy,
-) {
-    kd_sort_by(items, dim, |item1, item2, k| {
-        kd_key(item1, k).cmp(&kd_key(item2, k))
-    })
-}
 
 pub fn kd_sort_by<T>(
     items: &mut [T],
@@ -47,6 +17,32 @@ pub fn kd_sort_by<T>(
             let axis = (axis + 1) % dim;
             recurse(&mut items[..mid], axis, dim, kd_compare);
             recurse(&mut items[mid + 1..], axis, dim, kd_compare);
+        }
+    }
+    recurse(items, 0, dim, kd_compare);
+}
+
+#[cfg(feature = "rayon")]
+pub fn kd_par_sort_by<T: Send>(
+    items: &mut [T],
+    dim: usize,
+    kd_compare: impl Fn(&T, &T, usize) -> Ordering + Copy + Send,
+) {
+    fn recurse<T: Send>(
+        items: &mut [T],
+        axis: usize,
+        dim: usize,
+        kd_compare: impl Fn(&T, &T, usize) -> Ordering + Copy + Send,
+    ) {
+        if items.len() >= 2 {
+            pdqselect::select_by(items, items.len() / 2, |x, y| kd_compare(x, y, axis));
+            let mid = items.len() / 2;
+            let axis = (axis + 1) % dim;
+            let (lhs, rhs) = items.split_at_mut(mid);
+            rayon::join(
+                move || recurse(lhs, axis, dim, kd_compare),
+                move || recurse(&mut rhs[1..], axis, dim, kd_compare),
+            );
         }
     }
     recurse(items, 0, dim, kd_compare);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -90,5 +90,6 @@ fn vec<T>(count: usize, mut f: impl FnMut(usize) -> T) -> Vec<T> {
     let mut items = Vec::with_capacity(count);
     for i in 0..count {
         items.push(f(i));
-    }    items
+    }
+    items
 }


### PR DESCRIPTION
Adds optional `rayon` feature and `par_*` variants of sort & build methods that employ Rayon to perform sorting in parallel.

Even on an 4-core machine, this provides almost 2x improvement for large lists:
```
Benchmarking construct/kd_tree (f64)/4: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.8s, enable flat sampling, or reduce sample count to 50.
construct/kd_tree (f64)/4                                                                             
                        time:   [1.5249 ms 1.5296 ms 1.5350 ms]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
Benchmarking construct/kd_tree (i32)/4: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.1s, enable flat sampling, or reduce sample count to 60.
construct/kd_tree (i32)/4                                                                             
                        time:   [1.2005 ms 1.2036 ms 1.2069 ms]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
construct/kd_tree + rayon (f64)/4                                                                            
                        time:   [823.38 us 829.92 us 837.19 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
construct/kd_tree + rayon (i32)/4                                                                            
                        time:   [666.80 us 673.07 us 679.72 us]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```