### PR TITLE
Add a check to within to avoid panic on empty kdtree

### DIFF
--- a/src/within.rs
+++ b/src/within.rs
@@ -42,6 +42,9 @@ pub fn kd_within_by_cmp<T>(
         }
     }
     let mut results = Vec::new();
+    if kdtree.len() == 0{
+        return results
+    }
     recurse(&mut results, kdtree, 0, dim, compare);
     results
 }


### PR DESCRIPTION
Hi!
Love the crate, its powering parts of my microscopy particle detection algorithm. I just ran into a rare bug in which the kdtree I was querying against was empty, which resulted in a panic on line 18 in within.rs. I've just manually added a check to my code to ensure I never query against an empty kd-tree, but I thought you might have some interest in avoiding this edge-case as well.

Thanks for the great work :)