### PR TITLE
Switch from `typenum` crate to const generics for dimensional information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "typenum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 num-traits = "0.2.15"
 ordered-float = "3.0.0"
 pdqselect = "0.1.1"
-typenum = "1.15.0"
 paste = "1.0.8"
 rayon = { version = "1.5.3", optional = true }
 nalgebra = { version = "0.31.1", optional = true }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -9,7 +9,7 @@ fn bench_kdtree_construction(c: &mut Criterion) {
             log10n,
             |b, log10n| {
                 let points = gen_points3d(10usize.pow(*log10n));
-                b.iter(|| KdTree::build_by_ordered_float(points.clone()));
+                b.iter(|| KdTreeN::build_by_ordered_float(points.clone()));
             },
         );
         group.bench_with_input(
@@ -17,7 +17,7 @@ fn bench_kdtree_construction(c: &mut Criterion) {
             log10n,
             |b, log10n| {
                 let points = gen_points3i(10usize.pow(*log10n));
-                b.iter(|| KdTree::build(points.clone()));
+                b.iter(|| KdTreeN::build(points.clone()));
             },
         );
         #[cfg(feature = "rayon")]
@@ -27,7 +27,7 @@ fn bench_kdtree_construction(c: &mut Criterion) {
                 log10n,
                 |b, log10n| {
                     let points = gen_points3d(10usize.pow(*log10n));
-                    b.iter(|| KdTree::par_build_by_ordered_float(points.clone()));
+                    b.iter(|| KdTreeN::par_build_by_ordered_float(points.clone()));
                 },
             );
             group.bench_with_input(
@@ -35,7 +35,7 @@ fn bench_kdtree_construction(c: &mut Criterion) {
                 log10n,
                 |b, log10n| {
                     let points = gen_points3i(10usize.pow(*log10n));
-                    b.iter(|| KdTree::par_build(points.clone()));
+                    b.iter(|| KdTreeN::par_build(points.clone()));
                 },
             );
         }
@@ -44,7 +44,7 @@ fn bench_kdtree_construction(c: &mut Criterion) {
             log10n,
             |b, log10n| {
                 let points = gen_points3d(10usize.pow(*log10n));
-                b.iter(|| KdIndexTree::build_by_ordered_float(&points));
+                b.iter(|| KdIndexTreeN::build_by_ordered_float(&points));
             },
         );
         group.bench_with_input(
@@ -76,7 +76,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             BenchmarkId::new("kd_tree (f64)", log10n),
             log10n,
             |b, log10n| {
-                let kdtree = KdTree::build_by_ordered_float(gen_points3d(10usize.pow(*log10n)));
+                let kdtree = KdTreeN::build_by_ordered_float(gen_points3d(10usize.pow(*log10n)));
                 b.iter(|| {
                     let i = rng.gen::<usize>() % kdtree.len();
                     assert_eq!(
@@ -90,7 +90,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             BenchmarkId::new("kd_tree (i32)", log10n),
             log10n,
             |b, log10n| {
-                let kdtree = KdTree::build(gen_points3i(10usize.pow(*log10n)));
+                let kdtree = KdTreeN::build(gen_points3i(10usize.pow(*log10n)));
                 b.iter(|| {
                     let i = rng.gen::<usize>() % kdtree.len();
                     assert_eq!(
@@ -105,7 +105,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             log10n,
             |b, log10n| {
                 let points = gen_points3d(10usize.pow(*log10n));
-                let kdtree = KdIndexTree::build_by_ordered_float(&points);
+                let kdtree = KdIndexTreeN::build_by_ordered_float(&points);
                 b.iter(|| {
                     let i = rng.gen::<usize>() % points.len();
                     assert_eq!(kdtree.nearest(&points[i]).unwrap().item, &i);
@@ -116,7 +116,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             BenchmarkId::new("kd_tree/nearests", log10n),
             log10n,
             |b, log10n| {
-                let kdtree = KdTree::build_by_ordered_float(gen_points3d(10usize.pow(*log10n)));
+                let kdtree = KdTreeN::build_by_ordered_float(gen_points3d(10usize.pow(*log10n)));
                 b.iter(|| {
                     let i = rng.gen::<usize>() % kdtree.len();
                     assert_eq!(
@@ -171,8 +171,8 @@ fn bench_kdtree_k_nearest_search(c: &mut Criterion) {
         }
         kdtree
     };
-    let kd_tree = KdTree::build_by_ordered_float(points.clone());
-    let kd_index_tree = KdIndexTree::build_by_ordered_float(&points);
+    let kd_tree = KdTreeN::build_by_ordered_float(points.clone());
+    let kd_index_tree = KdIndexTreeN::build_by_ordered_float(&points);
     for k in &[1, 5, 10, 20, 50] {
         group.bench_with_input(BenchmarkId::new("kd_tree", k), k, |b, k| {
             b.iter(|| {
@@ -216,8 +216,8 @@ fn bench_kdtree_within_radius(c: &mut Criterion) {
         }
         kdtree
     };
-    let kd_tree = KdTree::build_by_ordered_float(points.clone());
-    let kd_index_tree = KdIndexTree::build_by_ordered_float(&points);
+    let kd_tree = KdTreeN::build_by_ordered_float(points.clone());
+    let kd_index_tree = KdIndexTreeN::build_by_ordered_float(&points);
     for radius in &[0.05, 0.1, 0.2, 0.4] {
         group.bench_with_input(BenchmarkId::new("kd_tree", radius), radius, |b, radius| {
             b.iter(|| {
@@ -261,9 +261,8 @@ struct TestItem<T> {
     coord: [T; 3],
     id: usize,
 }
-impl<T: num_traits::NumAssign + Copy + PartialOrd> KdPoint for TestItem<T> {
+impl<T: num_traits::NumAssign + Copy + PartialOrd> KdPoint<3> for TestItem<T> {
     type Scalar = T;
-    type Dim = typenum::U3;
     fn at(&self, k: usize) -> T {
         self.coord[k]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,6 @@ pub struct ItemAndDistance<'a, T, Scalar> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct KdSliceN<T, const N: usize>(PhantomData<[(); N]>, [T]);
 
-
 impl<T, const N: usize> std::ops::Deref for KdSliceN<T, N> {
     type Target = [T];
     fn deref(&self) -> &[T] {
@@ -419,7 +418,7 @@ impl<T: Send, const N: usize> KdSliceN<T, N> {
 /// An owned kd-tree.
 /// This type implements [`std::ops::Deref`] to [`KdSlice`].
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct KdTreeN<T, const N: usize>(PhantomData<[();N]>, Vec<T>);
+pub struct KdTreeN<T, const N: usize>(PhantomData<[(); N]>, Vec<T>);
 
 impl<T, const N: usize> std::ops::Deref for KdTreeN<T, N> {
     type Target = KdSliceN<T, N>;
@@ -803,8 +802,10 @@ macro_rules! define_kdtree_aliases {
 }
 define_kdtree_aliases!(1, 2, 3, 4, 5, 6, 7, 8);
 
-impl <T, const N: usize> KdPoint<N> for [T; N] 
-where T: num_traits::NumAssign + Copy + PartialOrd {
+impl<T, const N: usize> KdPoint<N> for [T; N]
+where
+    T: num_traits::NumAssign + Copy + PartialOrd,
+{
     type Scalar = T;
 
     fn at(&self, i: usize) -> Self::Scalar {
@@ -812,7 +813,7 @@ where T: num_traits::NumAssign + Copy + PartialOrd {
     }
 }
 
-impl<P: KdPoint<N>, T, const N: usize> KdPoint<{N}> for (P, T) {
+impl<P: KdPoint<N>, T, const N: usize> KdPoint<{ N }> for (P, T) {
     type Scalar = P::Scalar;
 
     fn at(&self, k: usize) -> Self::Scalar {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Usage
 //! ```
 //! // construct kd-tree
-//! let kdtree = kd_tree::KdTree::build_by_ordered_float(vec![
+//! let kdtree = kd_tree::KdTree3::build_by_ordered_float(vec![
 //!     [1.0, 2.0, 3.0],
 //!     [3.0, 1.0, 2.0],
 //!     [2.0, 3.0, 1.0],
@@ -45,12 +45,14 @@ use within::*;
 ///     point: [f64; 3],
 ///     id: usize,
 /// }
-/// impl kd_tree::KdPoint for MyItem {
+///
+/// impl kd_tree::KdPoint<3> for MyItem {
 ///     type Scalar = f64;
-///     type Dim = typenum::U3;
+///
 ///     fn at(&self, k: usize) -> f64 { self.point[k] }
 /// }
-/// let kdtree: kd_tree::KdTree<MyItem> = kd_tree::KdTree::build_by_ordered_float(vec![
+///
+/// let kdtree: kd_tree::KdTree3<MyItem> = kd_tree::KdTree3::build_by_ordered_float(vec![
 ///     MyItem { point: [1.0, 2.0, 3.0], id: 111 },
 ///     MyItem { point: [3.0, 1.0, 2.0], id: 222 },
 ///     MyItem { point: [2.0, 3.0, 1.0], id: 333 },
@@ -151,9 +153,9 @@ impl<T, const N: usize> KdSliceN<T, N> {
 
     /// # Example
     /// ```
-    /// use kd_tree::KdSlice;
+    /// use kd_tree::KdSlice3;
     /// let mut items: Vec<[f64; 3]> = vec![[1.0, 2.0, 3.0], [3.0, 1.0, 2.0], [2.0, 3.0, 1.0]];
-    /// let kdtree: &KdSlice<[f64; 3]> = KdSlice::sort_by_ordered_float(&mut items);
+    /// let kdtree: &KdSlice3<[f64; 3]> = KdSlice3::sort_by_ordered_float(&mut items);
     /// assert_eq!(kdtree.nearest(&[3.1, 0.9, 2.1]).unwrap().item, &[3.0, 1.0, 2.0]);
     /// ```
     pub fn sort_by_ordered_float(points: &mut [T]) -> &Self
@@ -166,9 +168,9 @@ impl<T, const N: usize> KdSliceN<T, N> {
 
     /// # Example
     /// ```
-    /// use kd_tree::KdSlice;
+    /// use kd_tree::KdSlice3;
     /// let mut items: Vec<[i32; 3]> = vec![[1, 2, 3], [3, 1, 2], [2, 3, 1]];
-    /// let kdtree: &KdSlice<[i32; 3]> = KdSlice::sort(&mut items);
+    /// let kdtree: &KdSlice3<[i32; 3]> = KdSlice3::sort(&mut items);
     /// assert_eq!(kdtree.nearest(&[3, 1, 2]).unwrap().item, &[3, 1, 2]);
     /// ```
     pub fn sort(points: &mut [T]) -> &Self
@@ -211,7 +213,7 @@ impl<T, const N: usize> KdSliceN<T, N> {
     /// # Example
     /// ```
     /// let mut items: Vec<[i32; 3]> = vec![[1, 2, 3], [3, 1, 2], [2, 3, 1]];
-    /// let kdtree = kd_tree::KdSlice::sort(&mut items);
+    /// let kdtree = kd_tree::KdSlice3::sort(&mut items);
     /// assert_eq!(kdtree.nearest(&[3, 1, 2]).unwrap().item, &[3, 1, 2]);
     /// ```
     pub fn nearest(
@@ -278,7 +280,7 @@ impl<T, const N: usize> KdSliceN<T, N> {
     /// # Example
     /// ```
     /// let mut items: Vec<[i32; 3]> = vec![[1, 2, 3], [3, 1, 2], [2, 3, 1], [3, 2, 2]];
-    /// let kdtree = kd_tree::KdSlice::sort(&mut items);
+    /// let kdtree = kd_tree::KdSlice3::sort(&mut items);
     /// let nearests = kdtree.nearests(&[3, 1, 2], 2);
     /// assert_eq!(nearests.len(), 2);
     /// assert_eq!(nearests[0].item, &[3, 1, 2]);
@@ -321,7 +323,7 @@ impl<T, const N: usize> KdSliceN<T, N> {
     /// # Example
     /// ```
     /// let mut items: Vec<[i32; 2]> = vec![[0, 0], [1, 0], [0, 1], [1, 1]];
-    /// let kdtree = kd_tree::KdSlice::sort(&mut items);
+    /// let kdtree = kd_tree::KdSlice2::sort(&mut items);
     /// let within = kdtree.within(&[[1, 0], [2, 1]]);
     /// assert_eq!(within.len(), 2);
     /// assert!(within.contains(&&[1, 0]));
@@ -498,8 +500,8 @@ impl<T, const N: usize> KdTreeN<T, N> {
 
     /// # Example
     /// ```
-    /// use kd_tree::KdTree;
-    /// let kdtree: KdTree<[f64; 3]> = KdTree::build_by_ordered_float(vec![
+    /// use kd_tree::KdTree3;
+    /// let kdtree: KdTree3<[f64; 3]> = KdTree3::build_by_ordered_float(vec![
     ///     [1.0, 2.0, 3.0], [3.0, 1.0, 2.0], [2.0, 3.0, 1.0]
     /// ]);
     /// assert_eq!(kdtree.nearest(&[3.1, 0.9, 2.1]).unwrap().item, &[3.0, 1.0, 2.0]);
@@ -514,8 +516,8 @@ impl<T, const N: usize> KdTreeN<T, N> {
 
     /// # Example
     /// ```
-    /// use kd_tree::KdTree;
-    /// let kdtree: KdTree<[i32; 3]> = KdTree::build(vec![[1, 2, 3], [3, 1, 2], [2, 3, 1]]);
+    /// use kd_tree::KdTree3;
+    /// let kdtree: KdTree3<[i32; 3]> = KdTree3::build(vec![[1, 2, 3], [3, 1, 2], [2, 3, 1]]);
     /// assert_eq!(kdtree.nearest(&[3, 1, 2]).unwrap().item, &[3, 1, 2]);
     /// ```
     pub fn build(points: Vec<T>) -> Self
@@ -686,7 +688,7 @@ impl<'a, T, const N: usize> KdIndexTreeN<'a, T, N> {
     /// # Example
     /// ```
     /// let mut items: Vec<[i32; 3]> = vec![[1, 2, 3], [3, 1, 2], [2, 3, 1], [3, 2, 2]];
-    /// let kdtree = kd_tree::KdIndexTree::build(&mut items);
+    /// let kdtree = kd_tree::KdIndexTree3::build(&mut items);
     /// let nearests = kdtree.nearests(&[3, 1, 2], 2);
     /// assert_eq!(nearests.len(), 2);
     /// assert_eq!(nearests[0].item, &1);
@@ -809,19 +811,17 @@ where T: num_traits::NumAssign + Copy + PartialOrd {
     }
 }
 
-// TODO: currently cannot be done without expressions in type constraints
-// https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html#const-generics-with-complex-expressions
-//impl<P: KdPoint<N>, T, const N: usize> KdPoint<{N+1}> for (P, T) {
-//    type Scalar = P::Scalar;
-//
-//    fn at(&self, k: usize) -> Self::Scalar {
-//        self.0.at(k)
-//    }
-//}
+impl<P: KdPoint<N>, T, const N: usize> KdPoint<{N}> for (P, T) {
+    type Scalar = P::Scalar;
+
+    fn at(&self, k: usize) -> Self::Scalar {
+        self.0.at(k)
+    }
+}
 
 /// kd-tree of key-value pairs.
 /// ```
-/// let kdmap: kd_tree::KdMap<[isize; 3], &'static str> = kd_tree::KdMap::build(vec![
+/// let kdmap: kd_tree::KdMap<[isize; 3], &'static str, 3> = kd_tree::KdMap::build(vec![
 ///     ([1, 2, 3], "foo"),
 ///     ([2, 3, 1], "bar"),
 ///     ([3, 1, 2], "buzz"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,13 +377,13 @@ impl<T, const N: usize> KdSliceN<T, N> {
 }
 
 #[cfg(feature = "rayon")]
-impl<T: Send, N: Unsigned> KdSliceN<T, N> {
+impl<T: Send, const N: usize> KdSliceN<T, N> {
     /// Same as [`Self::sort_by`], but using multiple threads.
     pub fn par_sort_by<F>(items: &mut [T], compare: F) -> &Self
     where
         F: Fn(&T, &T, usize) -> Ordering + Copy + Send,
     {
-        kd_par_sort_by(items, N::to_usize(), compare);
+        kd_par_sort_by(items, N, compare);
         unsafe { Self::new_unchecked(items) }
     }
 
@@ -400,7 +400,7 @@ impl<T: Send, N: Unsigned> KdSliceN<T, N> {
     /// Same as [`Self::sort_by_ordered_float`], but using multiple threads.
     pub fn par_sort_by_ordered_float(points: &mut [T]) -> &Self
     where
-        T: KdPoint<Dim = N>,
+        T: KdPoint<N>,
         T::Scalar: num_traits::Float,
     {
         Self::par_sort_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
@@ -409,7 +409,7 @@ impl<T: Send, N: Unsigned> KdSliceN<T, N> {
     /// Same as [`Self::sort`], but using multiple threads.
     pub fn par_sort(points: &mut [T]) -> &Self
     where
-        T: KdPoint<Dim = N>,
+        T: KdPoint<N>,
         T::Scalar: Ord,
     {
         Self::par_sort_by_key(points, |item, k| item.at(k))
@@ -545,13 +545,13 @@ mod impl_serde {
 }
 
 #[cfg(feature = "rayon")]
-impl<T: Send, N: Unsigned> KdTreeN<T, N> {
+impl<T: Send, const N: usize> KdTreeN<T, N> {
     /// Same as [`Self::build_by`], but using multiple threads.
     pub fn par_build_by<F>(mut items: Vec<T>, compare: F) -> Self
     where
         F: Fn(&T, &T, usize) -> Ordering + Copy + Send,
     {
-        kd_par_sort_by(&mut items, N::to_usize(), compare);
+        kd_par_sort_by(&mut items, N, compare);
         Self(PhantomData, items)
     }
 
@@ -569,7 +569,7 @@ impl<T: Send, N: Unsigned> KdTreeN<T, N> {
     /// Same as [`Self::build_by_ordered_float`], but using multiple threads.
     pub fn par_build_by_ordered_float(points: Vec<T>) -> Self
     where
-        T: KdPoint<Dim = N>,
+        T: KdPoint<N>,
         T::Scalar: num_traits::Float,
     {
         Self::par_build_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
@@ -578,7 +578,7 @@ impl<T: Send, N: Unsigned> KdTreeN<T, N> {
     /// Same as [`Self::build`], but using multiple threads.
     pub fn par_build(points: Vec<T>) -> Self
     where
-        T: KdPoint<Dim = N>,
+        T: KdPoint<N>,
         T::Scalar: Ord,
     {
         Self::par_build_by_key(points, |item, k| item.at(k))
@@ -749,7 +749,7 @@ impl<'a, T, const N: usize> KdIndexTreeN<'a, T, N> {
 }
 
 #[cfg(feature = "rayon")]
-impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
+impl<'a, T: Sync, const N: usize> KdIndexTreeN<'a, T, N> {
     pub fn par_build_by<F>(source: &'a [T], compare: F) -> Self
     where
         F: Fn(&T, &T, usize) -> Ordering + Copy + Send,
@@ -774,7 +774,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
 
     pub fn par_build_by_ordered_float(points: &'a [T]) -> Self
     where
-        T: KdPoint<Dim = N>,
+        T: KdPoint<N>,
         T::Scalar: num_traits::Float,
     {
         Self::par_build_by_key(points, |item, k| ordered_float::OrderedFloat(item.at(k)))
@@ -782,7 +782,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
 
     pub fn par_build(points: &'a [T]) -> Self
     where
-        T: KdPoint<Dim = N>,
+        T: KdPoint<N>,
         T::Scalar: Ord,
     {
         Self::par_build_by_key(points, |item, k| item.at(k))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub struct ItemAndDistance<'a, T, Scalar> {
 /// A slice of kd-tree.
 /// This type implements [`std::ops::Deref`] to `[T]`.
 /// This is an unsized type, meaning that it must always be used as a reference.
-/// For an owned version of this type, see [`KdTree`].
+/// For an owned version of this type, see [`KdTreeN`].
 #[derive(Debug, PartialEq, Eq)]
 pub struct KdSliceN<T, const N: usize>(PhantomData<[(); N]>, [T]);
 
@@ -416,7 +416,7 @@ impl<T: Send, const N: usize> KdSliceN<T, N> {
 }
 
 /// An owned kd-tree.
-/// This type implements [`std::ops::Deref`] to [`KdSlice`].
+/// This type implements [`std::ops::Deref`] to [`KdSliceN`].
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct KdTreeN<T, const N: usize>(PhantomData<[(); N]>, Vec<T>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,9 @@ pub struct ItemAndDistance<'a, T, Scalar> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct KdSliceN<T, const N: usize>(PhantomData<[(); N]>, [T]);
 
-pub type KdSlice<T> = KdSliceN<T, <T as KdPoint>::DIM>;
+pub type KdSlice1<T> = KdSliceN<T, 1>;
+pub type KdSlice2<T> = KdSliceN<T, 2>;
+pub type KdSlice3<T> = KdSliceN<T, 3>;
 
 impl<T, const N: usize> std::ops::Deref for KdSliceN<T, N> {
     type Target = [T];
@@ -420,7 +422,9 @@ impl<T: Send, N: Unsigned> KdSliceN<T, N> {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct KdTreeN<T, const N: usize>(PhantomData<[();N]>, Vec<T>);
 
-pub type KdTree<T> = KdTreeN<T, <T as KdPoint>::Dim>;
+pub type KdTree1<T> = KdTreeN<T, 1>;
+pub type KdTree2<T> = KdTreeN<T, 2>;
+pub type KdTree3<T> = KdTreeN<T, 3>;
 
 impl<T, const N: usize> std::ops::Deref for KdTreeN<T, N> {
     type Target = KdSliceN<T, N>;
@@ -599,7 +603,9 @@ pub struct KdIndexTreeN<'a, T, const N: usize> {
     kdtree: KdTreeN<usize, N>,
 }
 
-pub type KdIndexTree<'a, T> = KdIndexTreeN<'a, T, <T as KdPoint>::Dim>;
+pub type KdIndexTree1<'a, T> = KdIndexTreeN<'a, T, 1>;
+pub type KdIndexTree2<'a, T> = KdIndexTreeN<'a, T, 2>;
+pub type KdIndexTree3<'a, T> = KdIndexTreeN<'a, T, 3>;
 
 impl<'a, T, const N: usize> KdIndexTreeN<'a, T, N> {
     pub fn source(&self) -> &'a [T] {
@@ -837,7 +843,7 @@ impl<'a, T: Sync, N: Unsigned> KdIndexTreeN<'a, T, N> {
 /// ]);
 /// assert_eq!(kdmap.nearest(&[3, 1, 2]).unwrap().item.1, "buzz");
 /// ```
-pub type KdMap<P, T> = KdTree<(P, T)>;
+pub type KdMap<P, T, const N: usize> = KdTreeN<(P, T), N>;
 
 /// kd-tree slice of key-value pairs.
 /// ```
@@ -849,4 +855,4 @@ pub type KdMap<P, T> = KdTree<(P, T)>;
 /// let kdmap = kd_tree::KdMapSlice::sort(&mut items);
 /// assert_eq!(kdmap.nearest(&[3, 1, 2]).unwrap().item.1, "buzz");
 /// ```
-pub type KdMapSlice<P, T> = KdSlice<(P, T)>;
+pub type KdMapSlice<P, T, const N: usize> = KdSliceN<(P, T), N>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,13 +531,14 @@ impl<T, const N: usize> KdTreeN<T, N> {
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use super::{KdTreeN, PhantomData, Unsigned};
-    impl<T: serde::Serialize, N: Unsigned> serde::Serialize for KdTreeN<T, N> {
+    use super::{KdTreeN, PhantomData};
+
+    impl<T: serde::Serialize, const N: usize> serde::Serialize for KdTreeN<T, N> {
         fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
             self.1.serialize(serializer)
         }
     }
-    impl<'de, T: serde::Deserialize<'de>, N: Unsigned> serde::Deserialize<'de> for KdTreeN<T, N> {
+    impl<'de, T: serde::Deserialize<'de>, const N: usize> serde::Deserialize<'de> for KdTreeN<T, N> {
         fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
             Vec::<T>::deserialize(deserializer).map(|items| Self(PhantomData, items))
         }

--- a/src/nalgebra.rs
+++ b/src/nalgebra.rs
@@ -5,12 +5,12 @@ macro_rules! impl_kdpoint_for_nalgebra_point {
     ($($dim:literal),*) => {
         $(
             paste::paste! {
-                impl<Scalar> KdPoint for nalgebra::Point<Scalar, $dim>
+                impl<Scalar> KdPoint<$dim> for nalgebra::Point<Scalar, $dim>
                 where
                     Scalar: num_traits::NumAssign + Copy + PartialOrd + nalgebra::Scalar,
                 {
                     type Scalar = Scalar;
-                    type Dim = typenum::[<U $dim>];
+
                     fn at(&self, k: usize) -> Scalar {
                         self[k]
                     }
@@ -24,13 +24,13 @@ macro_rules! impl_kdpoint_for_nalgebra_vector {
     ($($dim:literal),*) => {
         $(
             paste::paste! {
-                impl<Scalar, Storage> KdPoint for nalgebra::Vector<Scalar, nalgebra::Const<$dim>, Storage>
+                impl<Scalar, Storage> KdPoint<$dim> for nalgebra::Vector<Scalar, nalgebra::Const<$dim>, Storage>
                 where
                     Scalar: num_traits::NumAssign + Copy + PartialOrd + nalgebra::Scalar,
                     Storage: nalgebra::StorageMut<Scalar, nalgebra::Const<$dim>>
                 {
                     type Scalar = Scalar;
-                    type Dim = typenum::[<U $dim>];
+
                     fn at(&self, k: usize) -> Scalar {
                         self[k]
                     }

--- a/src/nearest.rs
+++ b/src/nearest.rs
@@ -1,18 +1,18 @@
 use crate::{ItemAndDistance, KdPoint};
 
-pub fn kd_nearest<'a, T: KdPoint>(
+pub fn kd_nearest<'a, T: KdPoint<N>, const N: usize>(
     kdtree: &'a [T],
-    query: &impl KdPoint<Scalar = T::Scalar, Dim = T::Dim>,
+    query: &impl KdPoint<N, Scalar = T::Scalar>,
 ) -> ItemAndDistance<'a, T, T::Scalar> {
     kd_nearest_by(kdtree, query, |item, k| item.at(k))
 }
 
-pub fn kd_nearest_by<'a, T, P: KdPoint>(
+pub fn kd_nearest_by<'a, T, P: KdPoint<N>, const N: usize>(
     kdtree: &'a [T],
     query: &P,
     get: impl Fn(&T, usize) -> P::Scalar + Copy,
 ) -> ItemAndDistance<'a, T, P::Scalar> {
-    fn distance_squared<P: KdPoint, T>(
+    fn distance_squared<P: KdPoint<N>, T, const N: usize>(
         p1: &P,
         p2: &T,
         get: impl Fn(&T, usize) -> P::Scalar,
@@ -24,7 +24,7 @@ pub fn kd_nearest_by<'a, T, P: KdPoint>(
         }
         squared_distance
     }
-    fn recurse<'a, T, Q: KdPoint>(
+    fn recurse<'a, T, Q: KdPoint<N>, const N: usize>(
         nearest: &mut ItemAndDistance<'a, T, Q::Scalar>,
         kdtree: &'a [T],
         get: impl Fn(&T, usize) -> Q::Scalar + Copy,

--- a/src/nearests.rs
+++ b/src/nearests.rs
@@ -26,7 +26,7 @@ pub fn kd_nearests_by<'a, T, P: KdPoint<N>, const N: usize>(
         }
         squared_distance
     }
-    fn recurse<'a, T, Q: KdPoint<N>, const N : usize>(
+    fn recurse<'a, T, Q: KdPoint<N>, const N: usize>(
         nearests: &mut Vec<ItemAndDistance<'a, T, Q::Scalar>>,
         kdtree: &'a [T],
         get: impl Fn(&T, usize) -> Q::Scalar + Copy,

--- a/src/nearests.rs
+++ b/src/nearests.rs
@@ -1,20 +1,20 @@
 use crate::{ItemAndDistance, KdPoint};
 
-pub fn kd_nearests<'a, T: KdPoint>(
+pub fn kd_nearests<'a, T: KdPoint<N>, const N: usize>(
     kdtree: &'a [T],
-    query: &impl KdPoint<Scalar = T::Scalar, Dim = T::Dim>,
+    query: &impl KdPoint<N, Scalar = T::Scalar>,
     num: usize,
 ) -> Vec<ItemAndDistance<'a, T, T::Scalar>> {
     kd_nearests_by(kdtree, query, num, |item, k| item.at(k))
 }
 
-pub fn kd_nearests_by<'a, T, P: KdPoint>(
+pub fn kd_nearests_by<'a, T, P: KdPoint<N>, const N: usize>(
     kdtree: &'a [T],
     query: &P,
     num: usize,
     get: impl Fn(&T, usize) -> P::Scalar + Copy,
 ) -> Vec<ItemAndDistance<'a, T, P::Scalar>> {
-    fn distance_squared<P: KdPoint, T>(
+    fn distance_squared<P: KdPoint<N>, T, const N: usize>(
         p1: &P,
         p2: &T,
         get: impl Fn(&T, usize) -> P::Scalar,
@@ -26,7 +26,7 @@ pub fn kd_nearests_by<'a, T, P: KdPoint>(
         }
         squared_distance
     }
-    fn recurse<'a, T, Q: KdPoint>(
+    fn recurse<'a, T, Q: KdPoint<N>, const N : usize>(
         nearests: &mut Vec<ItemAndDistance<'a, T, Q::Scalar>>,
         kdtree: &'a [T],
         get: impl Fn(&T, usize) -> Q::Scalar + Copy,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 #[test]
 fn test_nearest() {
     let mut gen3d = random3d_generator();
-    let kdtree = KdTree::build_by_ordered_float(vec(10000, |_| gen3d()));
+    let kdtree = KdTree3::build_by_ordered_float(vec(10000, |_| gen3d()));
     for _ in 0..100 {
         let query = gen3d();
         let found = kdtree.nearest(&query).unwrap().item;
@@ -23,7 +23,7 @@ fn test_nearests() {
 }
 
 fn test_nearests_by(mut gen3d: impl FnMut() -> [f64; 3]) {
-    let kdtree = KdTree::build_by_ordered_float(vec(10000, |_| gen3d()));
+    let kdtree = KdTree3::build_by_ordered_float(vec(10000, |_| gen3d()));
     const NUM: usize = 5;
     for _ in 0..100 {
         let query = gen3d();
@@ -51,7 +51,7 @@ fn test_nearests_by(mut gen3d: impl FnMut() -> [f64; 3]) {
 #[test]
 fn test_within() {
     let mut gen3d = random3d_generator();
-    let kdtree = KdTree::build_by_ordered_float(vec(10000, |_| gen3d()));
+    let kdtree = KdTree3::build_by_ordered_float(vec(10000, |_| gen3d()));
     for _ in 0..100 {
         let mut p1 = gen3d();
         let mut p2 = gen3d();
@@ -71,14 +71,14 @@ fn test_within() {
 
 #[test]
 fn test_within_against_empty() {
-    let empty: KdTree<[f64; 3]> = KdTree::build_by_ordered_float(vec![]);
+    let empty: KdTree3<[f64; 3]> = KdTree3::build_by_ordered_float(vec![]);
     assert!(empty.within(&[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]).is_empty());
 }
 
 #[test]
 fn test_within_radius() {
     let mut gen3d = random3d_generator();
-    let kdtree = KdTree::build_by_ordered_float(vec(10000, |_| gen3d()));
+    let kdtree = KdTree3::build_by_ordered_float(vec(10000, |_| gen3d()));
     const RADIUS: f64 = 0.1;
     for _ in 0..100 {
         let query = gen3d();


### PR DESCRIPTION
In a project of mine I needed to generalize `KdPoint` over all `KdPoint<Dim=...>`, but `KdPoint` was only implemented for `[T; N]` where the dimension `N` was 1 to 16.

I updated the code to remove `typenum` and update the `KdPoint` trait from:

```rust
pub trait KdPoint {
    type Scalar: num_traits::NumAssign + Copy + PartialOrd;
    type Dim: Unsigned;
    fn dim() -> usize {
        <Self::Dim as Unsigned>::to_usize()
    }
    fn at(&self, i: usize) -> Self::Scalar;
}
```

to

```rust
pub trait KdPoint<const N: usize> {
    type Scalar: num_traits::NumAssign + Copy + PartialOrd;

    fn dim() -> usize {
        N
    }
    fn at(&self, i: usize) -> Self::Scalar;
}
```

and then update `KdSliceN`, `KdTreeN`, `KdIndexTreeN` to use the new const generics.

One side effect of this change is that since `Dim` is no longer an associated type of `KdPoint` you can no longer make the type alias

```rust
pub type KdTree<T> = KdTreeN<T, <T as KdPoint>::Dim>;
```

but, I think that you can simply use `KdTreeN` as a drop-in replacement. The removal of these aliases and `Dim` associated type is a breaking change. 

A positive side effect of the const generics makes error messages a bit easier to understand, as well as `KdPoint` being implemented for all `[T; N]`. I have done some benchmarking, and the two implementations (typenum, const generics) seem to have no difference in performance. 

You can merge this if you want; I don't mean to force my opinions into your project. I simply needed this for my project and thought I would upstream it if you find it beneficial!

Thanks for the crate.