### PR TITLE
Remove dependency on pdqselect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,6 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "paste",
- "pdqselect",
  "rand",
  "rayon",
  "serde",
@@ -384,12 +383,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pdqselect"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778906d9321dd56cde1d1ffa69a73e59dcf5fda6d366f62727adf2bd4193aee"
 
 [[package]]
 name = "plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 [dependencies]
 num-traits = "0.2.17"
 ordered-float = "3.9.2"
-pdqselect = "0.1.1"
 typenum = "1.17.0"
 paste = "1.0.14"
 rayon = { version = "1.8.0", optional = true }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -12,7 +12,7 @@ pub fn kd_sort_by<T>(
         kd_compare: impl Fn(&T, &T, usize) -> Ordering + Copy,
     ) {
         if items.len() >= 2 {
-            pdqselect::select_by(items, items.len() / 2, |x, y| kd_compare(x, y, axis));
+            items.select_nth_unstable_by(items.len() / 2, |x, y| kd_compare(x, y, axis));
             let mid = items.len() / 2;
             let axis = (axis + 1) % dim;
             recurse(&mut items[..mid], axis, dim, kd_compare);
@@ -35,7 +35,7 @@ pub fn kd_par_sort_by<T: Send>(
         kd_compare: impl Fn(&T, &T, usize) -> Ordering + Copy + Send,
     ) {
         if items.len() >= 2 {
-            pdqselect::select_by(items, items.len() / 2, |x, y| kd_compare(x, y, axis));
+            items.select_nth_unstable_by(items.len() / 2, |x, y| kd_compare(x, y, axis));
             let mid = items.len() / 2;
             let axis = (axis + 1) % dim;
             let (lhs, rhs) = items.split_at_mut(mid);


### PR DESCRIPTION
Use native select function available in modern Rust. Aside from one less dependency to compile, it's also quite a bit faster on floating-point KD-trees. Benchmark showing changes against main:

```
construct/kd_tree (f64)/2
                        time:   [3.8895 µs 3.9575 µs 4.0308 µs]
                        change: [-6.6814% -4.4286% -2.1402%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
construct/kd_tree (i32)/2
                        time:   [3.3568 µs 3.4155 µs 3.4740 µs]
                        change: [-2.2362% -0.3970% +1.4398%] (p = 0.67 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
construct/kd_tree (f64)/3
                        time:   [77.638 µs 78.353 µs 79.099 µs]
                        change: [-14.191% -12.984% -11.806%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
construct/kd_tree (i32)/3
                        time:   [60.246 µs 60.979 µs 61.712 µs]
                        change: [-2.8472% -1.5275% -0.1856%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking construct/kd_tree (f64)/4: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.3s, enable flat sampling, or reduce sample count to 60.
construct/kd_tree (f64)/4
                        time:   [1.1595 ms 1.1652 ms 1.1714 ms]
                        change: [-12.899% -11.530% -10.244%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
Benchmarking construct/kd_tree (i32)/4: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, enable flat sampling, or reduce sample count to 60.
construct/kd_tree (i32)/4
                        time:   [988.76 µs 993.55 µs 998.38 µs]
                        change: [-5.2209% -3.9712% -2.5079%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```