### PR TITLE
Relax ordered-float versions required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 num-traits = "0.2.17"
-ordered-float = "4.2.0"
+ordered-float = ">=4.2.0,<6"
 typenum = "1.17.0"
 paste = "1.0.14"
 rayon = { version = "1.10.0", optional = true }


### PR DESCRIPTION
- makes maintaining downstream repos easier.