### PR TITLE
Minor: Ran cargo outdated.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "approx"
@@ -34,27 +34,27 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "cast"
@@ -64,9 +64,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "ciborium"
@@ -97,18 +97,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -116,31 +116,28 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -153,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -183,9 +180,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -201,9 +198,9 @@ checksum = "216bf8256834a87394bf0364f82a92444ee8a00c757630a02a2bf278456f74e7"
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -222,27 +219,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -293,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "log"
@@ -305,9 +294,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -315,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "nalgebra"
@@ -480,15 +469,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -570,9 +559,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -620,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -645,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -886,18 +875,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nalgebra-serde = ["serde", "nalgebra", "nalgebra/serde-serialize"]
 
 [dev-dependencies]
 rand = "0.9.1"
-criterion = "0.5.1"
+criterion = "0.6.0"
 fux_kdtree = { version = "0.2.0", package = "fux_kdtree" }
 kdtree = "0.7.0"
 serde_json = "1.0"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -69,7 +69,7 @@ fn bench_kdtree_construction(c: &mut Criterion) {
 
 fn bench_kdtree_nearest_search(c: &mut Criterion) {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut group = c.benchmark_group("nearest");
     for log10n in &[2, 3, 4] {
         group.bench_with_input(
@@ -78,7 +78,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             |b, log10n| {
                 let kdtree = KdTree::build_by_ordered_float(gen_points3d(10usize.pow(*log10n)));
                 b.iter(|| {
-                    let i = rng.gen::<usize>() % kdtree.len();
+                    let i: usize = rng.random::<u128>() as usize % kdtree.len();
                     assert_eq!(
                         kdtree.nearest(&kdtree[i]).unwrap().item.coord,
                         kdtree[i].coord
@@ -92,7 +92,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             |b, log10n| {
                 let kdtree = KdTree::build(gen_points3i(10usize.pow(*log10n)));
                 b.iter(|| {
-                    let i = rng.gen::<usize>() % kdtree.len();
+                    let i: usize = rng.random::<u128>() as usize % kdtree.len();
                     assert_eq!(
                         kdtree.nearest(&kdtree[i]).unwrap().item.coord,
                         kdtree[i].coord
@@ -107,7 +107,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
                 let points = gen_points3d(10usize.pow(*log10n));
                 let kdtree = KdIndexTree::build_by_ordered_float(&points);
                 b.iter(|| {
-                    let i = rng.gen::<usize>() % points.len();
+                    let i: usize = rng.random::<u128>() as usize % points.len();
                     assert_eq!(kdtree.nearest(&points[i]).unwrap().item, &i);
                 });
             },
@@ -118,7 +118,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
             |b, log10n| {
                 let kdtree = KdTree::build_by_ordered_float(gen_points3d(10usize.pow(*log10n)));
                 b.iter(|| {
-                    let i = rng.gen::<usize>() % kdtree.len();
+                    let i: usize = rng.random::<u128>() as usize % kdtree.len();
                     assert_eq!(
                         kdtree.nearests(&kdtree[i], 1)[0].item.coord,
                         kdtree[i].coord
@@ -133,7 +133,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
                 let mut points = gen_points3d(10usize.pow(*log10n));
                 let kdtree = fux_kdtree::kdtree::Kdtree::new(&mut points);
                 b.iter(|| {
-                    let i = rng.gen::<usize>() % points.len();
+                    let i: usize = rng.random::<u128>() as usize % points.len();
                     assert_eq!(kdtree.nearest_search(&points[i]).coord, points[i].coord);
                 });
             },
@@ -145,7 +145,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
                 kdtree.add(&p.coord, p.id).unwrap();
             }
             b.iter(|| {
-                let i = rng.gen::<usize>() % points.len();
+                let i: usize = rng.random::<u128>() as usize % points.len();
                 assert_eq!(
                     kdtree
                         .nearest(&points[i].coord, 1, &kdtree::distance::squared_euclidean)
@@ -160,7 +160,7 @@ fn bench_kdtree_nearest_search(c: &mut Criterion) {
 
 fn bench_kdtree_k_nearest_search(c: &mut Criterion) {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut group = c.benchmark_group("nearests");
     const N: usize = 100000;
     let points = gen_points3d(N);
@@ -171,26 +171,27 @@ fn bench_kdtree_k_nearest_search(c: &mut Criterion) {
         }
         kdtree
     };
-    let kd_tree = KdTree::build_by_ordered_float(points.clone());
+    let kd_tree: kd_tree::KdTree<_> = KdTree::build_by_ordered_float(points.clone());
     let kd_index_tree = KdIndexTree::build_by_ordered_float(&points);
     for k in &[1, 5, 10, 20, 50] {
         group.bench_with_input(BenchmarkId::new("kd_tree", k), k, |b, k| {
             b.iter(|| {
-                let i = rng.gen::<usize>() % kd_tree.len();
+                let i: usize = rng.random::<u128>() as usize % kd_tree.len();
                 let nearests = kd_tree.nearests(&kd_tree[i], *k);
-                assert_eq!(nearests[0].item.coord, kd_tree[i].coord);
+                let computed = nearests[0].item.coord;
+                assert_eq!(computed, kd_tree[i].coord);
             });
         });
         group.bench_with_input(BenchmarkId::new("kd_index_tree", k), k, |b, k| {
             b.iter(|| {
-                let i = rng.gen::<usize>() % points.len();
+                let i: usize = rng.random::<u128>() as usize % points.len();
                 let nearests = kd_index_tree.nearests(&points[i], *k);
                 assert_eq!(nearests[0].item, &i);
             });
         });
         group.bench_with_input(BenchmarkId::new("kdtree", k), k, |b, k| {
             b.iter(|| {
-                let i = rng.gen::<usize>() % N;
+                let i: usize = rng.random::<u128>() as usize % N;
                 assert_eq!(
                     kdtree
                         .nearest(&points[i].coord, *k, &kdtree::distance::squared_euclidean)
@@ -205,7 +206,7 @@ fn bench_kdtree_k_nearest_search(c: &mut Criterion) {
 
 fn bench_kdtree_within_radius(c: &mut Criterion) {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut group = c.benchmark_group("within_radius");
     const N: usize = 100000;
     let points = gen_points3d(N);
@@ -221,7 +222,7 @@ fn bench_kdtree_within_radius(c: &mut Criterion) {
     for radius in &[0.05, 0.1, 0.2, 0.4] {
         group.bench_with_input(BenchmarkId::new("kd_tree", radius), radius, |b, radius| {
             b.iter(|| {
-                let i = rng.gen::<usize>() % kd_tree.len();
+                let i = rng.random::<u128>() as usize % kd_tree.len();
                 let _neighbors = kd_tree.within_radius(&kd_tree[i], *radius);
             });
         });
@@ -230,14 +231,14 @@ fn bench_kdtree_within_radius(c: &mut Criterion) {
             radius,
             |b, radius| {
                 b.iter(|| {
-                    let i = rng.gen::<usize>() % kd_tree.len();
+                    let i = rng.random::<u128>() as usize % kd_tree.len();
                     let _neighbors = kd_index_tree.within_radius(&points[i], *radius);
                 });
             },
         );
         group.bench_with_input(BenchmarkId::new("kdtree", radius), radius, |b, radius| {
             b.iter(|| {
-                let i = rng.gen::<usize>() % N;
+                let i = rng.random::<u128>() as usize % N;
                 let _neighbors = kdtree
                     .within(
                         &points[i].coord,
@@ -256,7 +257,7 @@ criterion_group!(benches3, bench_kdtree_k_nearest_search);
 criterion_group!(benches4, bench_kdtree_within_radius);
 criterion_main!(benches1, benches2, benches3, benches4);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd)]
 struct TestItem<T> {
     coord: [T; 3],
     id: usize,
@@ -276,10 +277,10 @@ impl fux_kdtree::kdtree::KdtreePointTrait for TestItem<f64> {
 
 fn gen_points3d(count: usize) -> Vec<TestItem<f64>> {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut points = Vec::with_capacity(count);
     for id in 0..count {
-        let coord = [rng.gen(), rng.gen(), rng.gen()];
+        let coord = [rng.random(), rng.random(), rng.random()];
         points.push(TestItem { coord, id });
     }
     points
@@ -287,14 +288,14 @@ fn gen_points3d(count: usize) -> Vec<TestItem<f64>> {
 
 fn gen_points3i(count: usize) -> Vec<TestItem<i32>> {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut points = Vec::with_capacity(count);
     const N: i32 = 1000;
     for id in 0..count {
         let coord = [
-            rng.gen::<i32>() % N,
-            rng.gen::<i32>() % N,
-            rng.gen::<i32>() % N,
+            rng.random::<i32>() % N,
+            rng.random::<i32>() % N,
+            rng.random::<i32>() % N,
         ];
         points.push(TestItem { coord, id });
     }


### PR DESCRIPTION
Fixed deprecated function names.

I must explain changes of this form 

let i: usize = rng.random::<u128>() as usize % N;

random::\<usize\> is not available for us
